### PR TITLE
Add lazy support

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -112,6 +112,9 @@ void DrawMapInputTypes() {
         m_URL = UI::InputText("##map-url", m_URL, pressedEnter, UI::InputTextFlags::EnterReturnsTrue);
         UI::SameLine();
         if (UI::Button("Play Map##main-btn") || pressedEnter) {
+            if (Regex::IsMatch(m_URL, "[0-9]{5,6}")) {
+                m_URL = tmxIdToUrl(m_URL);
+            }
             startnew(OnLoadMapNow);
         }
         UI::EndTabItem();

--- a/src/Main.as
+++ b/src/Main.as
@@ -112,6 +112,9 @@ void DrawMapInputTypes() {
         m_URL = UI::InputText("##map-url", m_URL, pressedEnter, UI::InputTextFlags::EnterReturnsTrue);
         UI::SameLine();
         if (UI::Button("Play Map##main-btn") || pressedEnter) {
+            if (m_URL.Contains("https://trackmania.exchange/tracks/view")) {
+                m_URL = Regex::Search(m_URL, "[0-9]{5,6}")[0];
+            }
             if (Regex::IsMatch(m_URL, "[0-9]{5,6}")) {
                 m_URL = tmxIdToUrl(m_URL);
             }


### PR DESCRIPTION
Users can punch either a raw TMX URL (5-6 digit numeric) or the full TMX link (e.g., https://trackmania.exchange/tracks/view/104226/reordered-scales) into the URL field and it'll recognize it and catch it.