### PR TITLE
Add local royal to supported game modes

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -124,7 +124,7 @@ string[] allModes = {
     "TrackMania/TM_Campaign_Local",
     "TrackMania/TM_StuntSolo_Local",
     "TrackMania/TM_Platform_Local",
-    "Trackmania/TM_RoyalTimeAttack_Local",
+    "TrackMania/TM_RoyalTimeAttack_Local",
     CustomGameModeLabel
     // "TrackMania/asdf"
 };

--- a/src/Main.as
+++ b/src/Main.as
@@ -124,6 +124,7 @@ string[] allModes = {
     "TrackMania/TM_Campaign_Local",
     "TrackMania/TM_StuntSolo_Local",
     "TrackMania/TM_Platform_Local",
+    "Trackmania/TM_RoyalTimeAttack_Local",
     CustomGameModeLabel
     // "TrackMania/asdf"
 };


### PR DESCRIPTION
With the [Fall 2024 update](https://www.trackmania.com/news/8226), Nadeo added the ability to play Royal maps locally:

> You’ll now be able to play Royal tracks in the solo game mode or locally with friends

This requires the "Trackmania/TM_RoyalTimeAttack_Local" game mode to load these maps.